### PR TITLE
swift version in podspec

### DIFF
--- a/ImageSource.podspec
+++ b/ImageSource.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.requires_arc = true
   s.default_subspec = 'Core', 'PHAsset', 'Local', 'Remote', 'AlamofireImage'
+  s.swift_version          = "4.0"
   
   s.subspec 'Core' do |cs|
   	cs.frameworks = 'CoreGraphics'


### PR DESCRIPTION
I didn't find documentation on this subject, but in the conversation https://github.com/CocoaPods/CocoaPods/issues/7327 you can find the following comment:

` if there is no swift_version specified then the Swift Version of your app target is used.`

This leads to the following behavior: if your project is written on version swift 4.2, then during `pod install`, an attempt will be made to build the library in version 4.2, which will lead to a crash. So, you must define the version in the following way, for example:

```
post_install do |installer|
  installer.pods_project.targets.each do |target|
    if ['AirMapSDK', 'PhoneNumberKit', 'Lock', 'RxSwift', 'RxSwiftExt', 'RxCocoa', 'RxDataSources', 'ProtocolBuffers-Swift'].include? target.name
      target.build_configurations.each do |config|
        config.build_settings['SWIFT_VERSION'] = '3.2'
      end
    end
  end
end
```

which is not very beautiful and not flexible.

So... maybe we have to specify swift_version in podspec file?