### PR TITLE
Add ability to set asset version to ImageRequestOptions

### DIFF
--- a/ImageSource/Core/ImageRequestOptions.swift
+++ b/ImageSource/Core/ImageRequestOptions.swift
@@ -1,21 +1,24 @@
 public struct ImageRequestOptions {
     
-    public var size: ImageSizeOption = .fullResolution
-    public var deliveryMode: ImageDeliveryMode = .best
+    public var size: ImageSizeOption
+    public var deliveryMode: ImageDeliveryMode
+    public var version: ImageRequestOptionsVersion
     public let needsMetadata: Bool
     
     /// Called on main thread when image download starts
     public var onDownloadStart: ((ImageRequestId) -> ())?
     /// Called on main thread when image download finishes
     public var onDownloadFinish: ((ImageRequestId) -> ())?
-    
-    public init() {
-        needsMetadata = false
-    }
-    
-    public init(size: ImageSizeOption, deliveryMode: ImageDeliveryMode, needsMetadata: Bool = false) {
+        
+    public init(
+        size: ImageSizeOption = .fullResolution,
+        deliveryMode: ImageDeliveryMode = .best,
+        version: ImageRequestOptionsVersion = .original,
+        needsMetadata: Bool = false
+    ) {
         self.size = size
         self.deliveryMode = deliveryMode
+        self.version = version
         self.needsMetadata = needsMetadata
     }
 }

--- a/ImageSource/Core/ImageRequestOptionsVersion.swift
+++ b/ImageSource/Core/ImageRequestOptionsVersion.swift
@@ -1,0 +1,13 @@
+/// Options for requesting an image asset with or without adjustments. 
+/// important: Can be applied to `PHAssetImageSource` only.
+public enum ImageRequestOptionsVersion {
+
+    /// Request the most recent version of the image asset (the one that reflects all edits).
+    case current
+
+    /// Request a version of the image asset without adjustments.
+    case unadjusted
+
+    /// Request the original, highest-fidelity version of the image asset.
+    case original
+}

--- a/ImageSource/PHAsset/PHAssetImageSource.swift
+++ b/ImageSource/PHAsset/PHAssetImageSource.swift
@@ -147,7 +147,7 @@ public final class PHAssetImageSource: ImageSource {
     private func imageRequestParameters(from options: ImageRequestOptions)
         -> (options: PHImageRequestOptions, size: CGSize, contentMode: PHImageContentMode)
     {
-        let phOptions = PHImageRequestOptions()
+        let phOptions: PHImageRequestOptions = PHImageRequestOptions()
         phOptions.isNetworkAccessAllowed = true
         
         switch options.deliveryMode {
@@ -157,6 +157,15 @@ public final class PHAssetImageSource: ImageSource {
         case .best:
             phOptions.deliveryMode = .highQualityFormat
             phOptions.resizeMode = .exact
+        }
+
+        switch options.version {
+        case .current:
+            phOptions.version = .current
+        case .original:
+            phOptions.version = .original
+        case .unadjusted:
+            phOptions.version = .unadjusted
         }
         
         let size: CGSize


### PR DESCRIPTION
Hello guys, please consider the following changes.

- Added ImageRequestOptionsVersion  proxy to PHImageRequestOptionsVersion, to be able to fetch exact version of the asset. Currently it is `.original` only.